### PR TITLE
docs: add docstrings for network analysis

### DIFF
--- a/blocksnet/analysis/network/__init__.py
+++ b/blocksnet/analysis/network/__init__.py
@@ -1,3 +1,5 @@
+"""Network analysis tools for accessibility, connectivity and congestion."""
+
 from .accessibility import *
 from .connectivity import *
 from .origin_destination import *

--- a/blocksnet/analysis/network/accessibility/__init__.py
+++ b/blocksnet/analysis/network/accessibility/__init__.py
@@ -1,3 +1,5 @@
+"""Accessibility-related indicators for transport and land-use networks."""
+
 from .basic import *
 from .area import area_accessibility
 from .land_use import land_use_accessibility, land_use_accessibility_matrix

--- a/blocksnet/analysis/network/accessibility/area.py
+++ b/blocksnet/analysis/network/accessibility/area.py
@@ -1,5 +1,8 @@
+"""Area-weighted accessibility indicators."""
+
 import pandas as pd
 from blocksnet.relations import validate_accessibility_matrix
+
 from .schemas import AreaAccessibilityBlocksSchema
 
 AREA_ACCESSIBILITY_COLUMN = "area_accessibility"
@@ -10,6 +13,31 @@ def area_accessibility(
     blocks_df: pd.DataFrame,
     out: bool = True,
 ) -> pd.DataFrame:
+    """Calculate an area-weighted accessibility score for blocks.
+
+    Parameters
+    ----------
+    accessibility_matrix : pandas.DataFrame
+        Accessibility weights between origin blocks (rows) and destination blocks (columns).
+    blocks_df : pandas.DataFrame
+        Block attributes containing ``site_area``. The dataframe is validated with
+        :class:`AreaAccessibilityBlocksSchema` to ensure non-negative areas.
+    out : bool, default True
+        If ``True``, aggregate accessibility for origins (matrix rows). If ``False``, compute
+        aggregated accessibility for destinations (matrix columns).
+
+    Returns
+    -------
+    pandas.DataFrame
+        A single-column dataframe named ``area_accessibility`` with an area-weighted accessibility
+        value for each block.
+
+    Raises
+    ------
+    ValueError
+        If the matrix labels are inconsistent with the validated block index depending on the
+        ``out`` orientation.
+    """
 
     validate_accessibility_matrix(
         accessibility_matrix,
@@ -25,10 +53,9 @@ def area_accessibility(
         s_cols = blocks_df.loc[accessibility_matrix.columns, "site_area"]
         result = (accessibility_matrix.mul(s_cols, axis=1)).sum(axis=1) / s_cols.sum()
         return pd.DataFrame(result, index=accessibility_matrix.index, columns=[AREA_ACCESSIBILITY_COLUMN])
-    else:
-        if not accessibility_matrix.index.isin(blocks_df.index).all():
-            raise ValueError("Accessibility matrix index must be in blocks index")
+    if not accessibility_matrix.index.isin(blocks_df.index).all():
+        raise ValueError("Accessibility matrix index must be in blocks index")
 
-        s_rows = blocks_df.loc[accessibility_matrix.index, "site_area"]
-        result = (accessibility_matrix.mul(s_rows, axis=0)).sum(axis=0) / s_rows.sum()
-        return pd.DataFrame(result, index=accessibility_matrix.columns, columns=[AREA_ACCESSIBILITY_COLUMN])
+    s_rows = blocks_df.loc[accessibility_matrix.index, "site_area"]
+    result = (accessibility_matrix.mul(s_rows, axis=0)).sum(axis=0) / s_rows.sum()
+    return pd.DataFrame(result, index=accessibility_matrix.columns, columns=[AREA_ACCESSIBILITY_COLUMN])

--- a/blocksnet/analysis/network/accessibility/basic.py
+++ b/blocksnet/analysis/network/accessibility/basic.py
@@ -1,6 +1,10 @@
+"""Generic accessibility aggregation helpers."""
+
 from typing import Callable
+
 import numpy as np
 import pandas as pd
+
 from blocksnet.relations import validate_accessibility_matrix
 
 ACCESSIBILITY_COLUMN = "accessibility"
@@ -12,6 +16,30 @@ MAX_ACCESSIBILITY_COLUMN = "max_accessibility"
 def _accessibility(
     accessibility_matrix: pd.DataFrame, agg_func: Callable, out: bool, accessibility_column: str
 ) -> pd.DataFrame:
+    """Aggregate an accessibility matrix with a custom reducer.
+
+    Parameters
+    ----------
+    accessibility_matrix : pandas.DataFrame
+        Accessibility weights between origins (rows) and destinations (columns).
+    agg_func : Callable
+        Callable that reduces the matrix along the axis corresponding to ``out``.
+    out : bool
+        If ``True`` aggregate accessibility for origin rows, otherwise aggregate for destination columns.
+    accessibility_column : str
+        Name of the resulting column containing aggregated values.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Single-column dataframe containing aggregated accessibility values.
+
+    Raises
+    ------
+    ValueError
+        If the provided matrix violates basic accessibility matrix validation rules.
+    """
+
     validate_accessibility_matrix(accessibility_matrix, check_squared=False)
     df = pd.DataFrame(index=accessibility_matrix.index if out else accessibility_matrix.columns)
     df[accessibility_column] = agg_func(accessibility_matrix.values, axis=1 if out else 0)
@@ -24,22 +52,86 @@ def accessibility(
     out: bool = True,
     accessibility_column: str = ACCESSIBILITY_COLUMN,
 ) -> pd.DataFrame:
+    """Aggregate accessibility values with a user-provided reducer.
+
+    Parameters
+    ----------
+    accessibility_matrix : pandas.DataFrame
+        Accessibility weights between origin and destination blocks.
+    agg_func : Callable
+        Aggregation callable applied along axis 1 (origins) when ``out`` is ``True`` and along axis 0 otherwise.
+    out : bool, default True
+        Determines whether the aggregation is calculated for origins or destinations.
+    accessibility_column : str, default ``ACCESSIBILITY_COLUMN``
+        Column name assigned to the aggregated result.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Aggregated accessibility values for each block.
+    """
+
     return _accessibility(accessibility_matrix, out=out, agg_func=agg_func, accessibility_column=accessibility_column)
 
 
 def median_accessibility(accessibility_matrix: pd.DataFrame, out: bool = True) -> pd.DataFrame:
+    """Calculate the median accessibility score for each block.
+
+    Parameters
+    ----------
+    accessibility_matrix : pandas.DataFrame
+        Accessibility weights between origins and destinations.
+    out : bool, default True
+        If ``True``, compute median accessibility for origins; otherwise for destinations.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Median accessibility values named ``median_accessibility``.
+    """
+
     return _accessibility(
         accessibility_matrix, out=out, agg_func=np.median, accessibility_column=MEDIAN_ACCESSIBILITY_COLUMN
     )
 
 
 def mean_accessibility(accessibility_matrix: pd.DataFrame, out: bool = True) -> pd.DataFrame:
+    """Calculate the mean accessibility score for each block.
+
+    Parameters
+    ----------
+    accessibility_matrix : pandas.DataFrame
+        Accessibility weights between origins and destinations.
+    out : bool, default True
+        If ``True``, compute mean accessibility for origins; otherwise for destinations.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Mean accessibility values named ``mean_accessibility``.
+    """
+
     return _accessibility(
         accessibility_matrix, out=out, agg_func=np.mean, accessibility_column=MEAN_ACCESSIBILITY_COLUMN
     )
 
 
 def max_accessibility(accessibility_matrix: pd.DataFrame, out: bool = True) -> pd.DataFrame:
+    """Calculate the maximum accessibility value for each block.
+
+    Parameters
+    ----------
+    accessibility_matrix : pandas.DataFrame
+        Accessibility weights between origins and destinations.
+    out : bool, default True
+        If ``True``, compute the maximum for origins; otherwise for destinations.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Maximum accessibility values named ``max_accessibility``.
+    """
+
     return _accessibility(accessibility_matrix, out=out, agg_func=np.max, accessibility_column=MAX_ACCESSIBILITY_COLUMN)
 
 

--- a/blocksnet/analysis/network/accessibility/land_use.py
+++ b/blocksnet/analysis/network/accessibility/land_use.py
@@ -1,10 +1,15 @@
+"""Land-use specific accessibility indicators."""
+
 from typing import Callable
+
 import numpy as np
 import pandas as pd
+
 from blocksnet.enums import LandUse
+from blocksnet.relations import validate_accessibility_matrix
+
 from .basic import _accessibility
 from .schemas import LandUseAccessibilityBlocksSchema
-from blocksnet.relations import validate_accessibility_matrix
 
 LAND_USE_ACCESSIBILITY_COLUMN = "land_use_accessibility"
 
@@ -16,6 +21,34 @@ def land_use_accessibility(
     out: bool = True,
     agg_func: Callable = np.median,
 ) -> pd.DataFrame:
+    """Aggregate accessibility for blocks of a specific land-use class.
+
+    Parameters
+    ----------
+    accessibility_matrix : pandas.DataFrame
+        Accessibility weights between origin and destination blocks.
+    blocks_df : pandas.DataFrame
+        Block attributes validated by :class:`LandUseAccessibilityBlocksSchema` containing ``land_use`` values.
+    land_use : LandUse
+        Target land-use category to aggregate accessibility for. Must be an instance of :class:`LandUse`.
+    out : bool, default True
+        Orientation of aggregation. ``True`` aggregates for origins, ``False`` for destinations.
+    agg_func : Callable, default numpy.median
+        Aggregation function applied to the filtered accessibility matrix.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Aggregated accessibility values restricted to the selected land-use class.
+
+    Raises
+    ------
+    TypeError
+        If ``land_use`` is not an instance of :class:`LandUse`.
+    ValueError
+        If the accessibility matrix fails validation against the provided blocks dataframe.
+    """
+
     if not isinstance(land_use, LandUse):
         raise TypeError(f"land_use must be an instance of {LandUse.__name__}")
     blocks_df = LandUseAccessibilityBlocksSchema(blocks_df)
@@ -28,6 +61,28 @@ def land_use_accessibility(
 def land_use_accessibility_matrix(
     accessibility_matrix: pd.DataFrame, blocks_df: pd.DataFrame, agg_func: Callable = np.median
 ) -> pd.DataFrame:
+    """Summarise accessibility between all land-use classes.
+
+    Parameters
+    ----------
+    accessibility_matrix : pandas.DataFrame
+        Accessibility weights between origin and destination blocks.
+    blocks_df : pandas.DataFrame
+        Block attributes validated by :class:`LandUseAccessibilityBlocksSchema` containing ``land_use`` values.
+    agg_func : Callable, default numpy.median
+        Aggregation function applied to each pairwise submatrix of land-use groups.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A square matrix indexed by :class:`~blocksnet.enums.LandUse` with aggregated accessibility values.
+
+    Raises
+    ------
+    ValueError
+        If the accessibility matrix fails validation against the provided blocks dataframe.
+    """
+
     validate_accessibility_matrix(
         accessibility_matrix, blocks_df=blocks_df, index=True, columns=True, check_squared=False
     )

--- a/blocksnet/analysis/network/accessibility/relative.py
+++ b/blocksnet/analysis/network/accessibility/relative.py
@@ -1,12 +1,39 @@
+"""Relative accessibility indicator utilities."""
+
 import pandas as pd
+
 from blocksnet.relations import validate_accessibility_matrix
 
 RELATIVE_ACCESSIBILITY_COLUMN = "relative_accessibility"
 
 
 def relative_accessibility(accessibility_matrix: pd.DataFrame, i: int, out: bool = True) -> pd.DataFrame:
+    """Extract relative accessibility scores for a selected block.
+
+    Parameters
+    ----------
+    accessibility_matrix : pandas.DataFrame
+        Accessibility weights between origin and destination blocks.
+    i : int
+        Identifier of the block for which relative accessibility is requested. The identifier must
+        exist either in the matrix index (for ``out=True``) or columns (for ``out=False``).
+    out : bool, default True
+        Orientation of the returned scores. ``True`` returns accessibility from block ``i`` to all
+        destinations, while ``False`` returns accessibility to block ``i`` from all origins.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A dataframe with a ``relative_accessibility`` column indexed by the origin blocks.
+
+    Raises
+    ------
+    ValueError
+        If ``i`` is absent from the relevant axis of the accessibility matrix.
+    """
+
     validate_accessibility_matrix(accessibility_matrix, check_squared=False)
-    if not i in (accessibility_matrix.index if out else accessibility_matrix.columns):
+    if i not in (accessibility_matrix.index if out else accessibility_matrix.columns):
         raise ValueError(f"i={i} must be in matrix {'index' if out else 'columns'}")
     df = pd.DataFrame(index=accessibility_matrix.index)
     df[RELATIVE_ACCESSIBILITY_COLUMN] = accessibility_matrix.loc[i] if out else accessibility_matrix[i]

--- a/blocksnet/analysis/network/accessibility/schemas.py
+++ b/blocksnet/analysis/network/accessibility/schemas.py
@@ -1,11 +1,18 @@
+"""Validation schemas for accessibility indicators."""
+
 from pandera.typing import Series
 from pandera import Field
+
 from blocksnet.utils.validation import DfSchema, LandUseSchema
 
 
 class AreaAccessibilityBlocksSchema(DfSchema):
+    """Validate block areas used for area-weighted accessibility calculations."""
+
     site_area: Series[float] = Field(ge=0)
 
 
 class LandUseAccessibilityBlocksSchema(LandUseSchema):
+    """Validate block land-use assignments for land-use accessibility statistics."""
+
     pass

--- a/blocksnet/analysis/network/accessibility/utils.py
+++ b/blocksnet/analysis/network/accessibility/utils.py
@@ -1,3 +1,5 @@
+"""Utility helpers for accessibility calculations (currently unused)."""
+
 # import pandas as pd
 # from functools import wraps
 # from blocksnet.relations import validate_accessibility_matrix as validate_acc_mx

--- a/blocksnet/analysis/network/classification/__init__.py
+++ b/blocksnet/analysis/network/classification/__init__.py
@@ -1,1 +1,3 @@
+"""Graph-based settlement classification utilities."""
+
 from .core import NetworkClassifier

--- a/blocksnet/analysis/network/classification/_strategy.py
+++ b/blocksnet/analysis/network/classification/_strategy.py
@@ -1,4 +1,7 @@
+"""Pre-configured classification strategy artefacts."""
+
 from pathlib import Path
+
 from blocksnet.machine_learning.strategy.catboost import CatBoostClassificationStrategy
 
 CURRENT_DIRECTORY = Path(__file__).parent

--- a/blocksnet/analysis/network/classification/core.py
+++ b/blocksnet/analysis/network/classification/core.py
@@ -1,3 +1,5 @@
+"""Supervised classification utilities for street-network morphology."""
+
 import networkx as nx
 import pandas as pd
 import numpy as np
@@ -5,10 +7,12 @@ from tqdm import tqdm
 from loguru import logger
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score
+
 from blocksnet.machine_learning import BaseContext
 from blocksnet.enums import SettlementCategory
 from blocksnet.config import log_config
 from blocksnet.machine_learning.strategy import BaseStrategy, ClassificationBase
+
 from .utils import CATEGORY_KEY, preprocess_graph, calculate_graph_features
 from ._strategy import strategy
 
@@ -16,20 +20,77 @@ CATEGORIES_LIST = list(SettlementCategory)
 
 
 class NetworkClassifier(BaseContext):
+    """Train and run settlement category classifiers on street-network graphs.
+
+    Parameters
+    ----------
+    strategy : BaseStrategy
+        Machine-learning strategy implementing ``train`` and ``predict`` methods.
+    """
+
     def __init__(self, strategy: BaseStrategy):
+        """Initialise the classifier context with a strategy."""
+
         super().__init__(strategy=strategy)
         self._train_data: pd.DataFrame | None = None
 
     def prepare_train(self, graphs: list[nx.Graph]):
+        """Build the training dataframe from labelled graphs.
+
+        Parameters
+        ----------
+        graphs : list of networkx.Graph
+            Graphs annotated with settlement categories in ``graph.graph[CATEGORY_KEY]``.
+
+        Returns
+        -------
+        None
+        """
+
         self._train_data = self._get_features_df(graphs, with_category=True)
 
     @property
     def train_data(self) -> pd.DataFrame:
+        """Return a copy of the prepared training dataframe.
+
+        Returns
+        -------
+        pandas.DataFrame
+            Feature dataframe built during :meth:`prepare_train`.
+
+        Raises
+        ------
+        ValueError
+            If training data have not been prepared yet.
+        """
+
         if self._train_data is None:
-            raise ValueError(f"No train data found. One must prepare it first using prepare_train() method.")
+            raise ValueError("No train data found. One must prepare it first using prepare_train() method.")
         return self._train_data.copy()
 
     def _get_features_df(self, graphs: list[nx.Graph], with_category: bool) -> pd.DataFrame:
+        """Convert graphs into a feature dataframe.
+
+        Parameters
+        ----------
+        graphs : list of networkx.Graph
+            Graphs to transform into feature vectors.
+        with_category : bool
+            Whether to validate and include settlement category labels.
+
+        Returns
+        -------
+        pandas.DataFrame
+            Tabular features describing the supplied graphs.
+
+        Raises
+        ------
+        KeyError
+            If category metadata are requested but missing from a graph.
+        TypeError
+            If category metadata cannot be converted to :class:`SettlementCategory`.
+        """
+
         logger.info("Preprocessing graphs.")
         graphs = [
             preprocess_graph(g, validate_category=with_category) for g in tqdm(graphs, disable=log_config.disable_tqdm)
@@ -46,14 +107,60 @@ class NetworkClassifier(BaseContext):
         return pd.DataFrame(features_dicts)
 
     def _preprocess_x(self, features_df: pd.DataFrame) -> np.ndarray:
+        """Extract model features from the dataframe.
+
+        Parameters
+        ----------
+        features_df : pandas.DataFrame
+            Dataframe containing model features and optionally encoded categories.
+
+        Returns
+        -------
+        numpy.ndarray
+            Feature matrix for the learning algorithm.
+        """
+
         if CATEGORY_KEY in features_df.columns:
             features_df = features_df.drop(columns=[CATEGORY_KEY])
         return features_df.values
 
     def _preprocess_y(self, features_df: pd.DataFrame) -> np.ndarray:
+        """Extract encoded target labels from the dataframe.
+
+        Parameters
+        ----------
+        features_df : pandas.DataFrame
+            Dataframe containing an encoded ``CATEGORY_KEY`` column.
+
+        Returns
+        -------
+        numpy.ndarray
+            Column vector of encoded class labels.
+        """
+
         return features_df[[CATEGORY_KEY]].values
 
     def train(self, metric=accuracy_score, split_params: dict | None = None):
+        """Fit the configured strategy using the prepared training data.
+
+        Parameters
+        ----------
+        metric : Callable, default sklearn.metrics.accuracy_score
+            Evaluation metric applied to predictions on the validation split.
+        split_params : dict, optional
+            Keyword arguments passed to :func:`sklearn.model_selection.train_test_split`.
+
+        Returns
+        -------
+        float
+            Evaluation score computed using ``metric`` on the validation set.
+
+        Raises
+        ------
+        ValueError
+            If training data have not yet been prepared.
+        """
+
         features_df = self.train_data
 
         x = self._preprocess_x(features_df)
@@ -67,6 +174,19 @@ class NetworkClassifier(BaseContext):
         return metric(y_pred, y_test)
 
     def run(self, graphs: list[nx.Graph]) -> pd.DataFrame:
+        """Predict settlement categories for unlabelled graphs.
+
+        Parameters
+        ----------
+        graphs : list of networkx.Graph
+            Graphs without category labels.
+
+        Returns
+        -------
+        pandas.DataFrame
+            Feature dataframe including predicted settlement categories and optional probabilities.
+        """
+
         features_df = self._get_features_df(graphs, with_category=False)
 
         x = self._preprocess_x(features_df)
@@ -83,4 +203,6 @@ class NetworkClassifier(BaseContext):
 
     @classmethod
     def default(cls) -> "NetworkClassifier":
+        """Instantiate a classifier with the default CatBoost-based strategy."""
+
         return cls(strategy)

--- a/blocksnet/analysis/network/classification/utils/__init__.py
+++ b/blocksnet/analysis/network/classification/utils/__init__.py
@@ -1,2 +1,4 @@
+"""Utility helpers for transforming graphs prior to classification."""
+
 from .features import calculate_graph_features
 from .preprocessing import preprocess_graph, graph_to_gdf, CATEGORY_KEY

--- a/blocksnet/analysis/network/classification/utils/features.py
+++ b/blocksnet/analysis/network/classification/utils/features.py
@@ -1,12 +1,27 @@
+"""Feature engineering helpers for the network classifier."""
+
 import networkx as nx
 import numpy as np
 from sklearn.neighbors import NearestNeighbors
 from scipy.stats import entropy
+
 from .preprocessing import graph_to_gdf
 
 
 def _avg_neighbor_distance(gdf):
-    """Compute average nearest neighbor distance"""
+    """Compute the average nearest-neighbour distance between graph nodes.
+
+    Parameters
+    ----------
+    gdf : geopandas.GeoDataFrame
+        GeoDataFrame containing node geometries.
+
+    Returns
+    -------
+    float
+        Average distance to the nearest neighbour, or ``nan`` if insufficient nodes.
+    """
+
     coords = np.array([[pt.x, pt.y] for pt in gdf.geometry if not pt.is_empty])
     if len(coords) < 2:
         return np.nan
@@ -16,7 +31,19 @@ def _avg_neighbor_distance(gdf):
 
 
 def _link_length_entropy(lengths):
-    """Calculate entropy of link length distribution"""
+    """Estimate the entropy of the link-length distribution.
+
+    Parameters
+    ----------
+    lengths : Sequence[float]
+        Edge length values extracted from the graph geometry.
+
+    Returns
+    -------
+    float
+        Shannon entropy of the link-length histogram.
+    """
+
     if len(lengths) < 2:
         return 0.0
     counts, _ = np.histogram(lengths, bins="auto")
@@ -25,6 +52,19 @@ def _link_length_entropy(lengths):
 
 
 def calculate_graph_features(graph: nx.Graph) -> dict:
+    """Derive structural and geometric indicators from a graph.
+
+    Parameters
+    ----------
+    graph : networkx.Graph
+        Graph describing the street network with geographic node coordinates.
+
+    Returns
+    -------
+    dict
+        Mapping of feature names to numeric values capturing topology and geometry.
+    """
+
     gdf = graph_to_gdf(graph)
     # Edge length calculations
     edge_lengths = []

--- a/blocksnet/analysis/network/connectivity/__init__.py
+++ b/blocksnet/analysis/network/connectivity/__init__.py
@@ -1,1 +1,3 @@
+"""Connectivity metrics derived from accessibility indicators."""
+
 from .core import calculate_connectivity

--- a/blocksnet/analysis/network/connectivity/core.py
+++ b/blocksnet/analysis/network/connectivity/core.py
@@ -1,4 +1,7 @@
+"""Connectivity metrics derived from accessibility scores."""
+
 import pandas as pd
+
 from .schemas import BlocksAccessibilitySchema
 
 CONNECTIVITY_COLUMN = "connectivity"
@@ -6,6 +9,24 @@ ACCESSIBILITY_SUFFIX = "_accessibility"
 
 
 def _preprocess_and_validate(accessibility_df: pd.DataFrame) -> pd.DataFrame:
+    """Validate and normalise an accessibility dataframe.
+
+    Parameters
+    ----------
+    accessibility_df : pandas.DataFrame
+        Accessibility indicators containing a single column with the ``_accessibility`` suffix.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Validated dataframe with the column renamed to ``accessibility``.
+
+    Raises
+    ------
+    ValueError
+        If no or multiple accessibility columns are found.
+    """
+
     columns = [c for c in accessibility_df.columns if ACCESSIBILITY_SUFFIX in c]
     if len(columns) > 1:
         raise ValueError(
@@ -19,6 +40,24 @@ def _preprocess_and_validate(accessibility_df: pd.DataFrame) -> pd.DataFrame:
 
 
 def calculate_connectivity(accessibility_df: pd.DataFrame):
+    """Convert accessibility scores into connectivity metrics.
+
+    Parameters
+    ----------
+    accessibility_df : pandas.DataFrame
+        Dataframe with a single column named ``*_accessibility`` containing accessibility scores.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Dataframe containing a ``connectivity`` column with reciprocal accessibility values.
+
+    Raises
+    ------
+    ValueError
+        If no or multiple accessibility columns are detected or if validation fails.
+    """
+
     accessibility_df = _preprocess_and_validate(accessibility_df)
     accessibility_df[CONNECTIVITY_COLUMN] = 1.0 / accessibility_df["accessibility"]
     return accessibility_df[[CONNECTIVITY_COLUMN]].copy()

--- a/blocksnet/analysis/network/connectivity/schemas.py
+++ b/blocksnet/analysis/network/connectivity/schemas.py
@@ -1,7 +1,12 @@
+"""Validation schema for connectivity indicators."""
+
 from pandera.typing import Series
 from pandera import Field
+
 from blocksnet.utils.validation import DfSchema
 
 
 class BlocksAccessibilitySchema(DfSchema):
+    """Ensure accessibility values are non-negative prior to inversion."""
+
     accessibility: Series[float] = Field(ge=0)

--- a/blocksnet/analysis/network/origin_destination/__init__.py
+++ b/blocksnet/analysis/network/origin_destination/__init__.py
@@ -1,2 +1,4 @@
+"""Origin-destination matrix estimation helpers."""
+
 from .core import origin_destination_matrix
 from .schemas import validate_od_matrix

--- a/blocksnet/analysis/network/origin_destination/schemas.py
+++ b/blocksnet/analysis/network/origin_destination/schemas.py
@@ -1,17 +1,24 @@
+"""Validation utilities for origin-destination modelling."""
+
 import shapely
 import pandas as pd
 import networkx as nx
 from pandera import Field
 from pandera.typing import Series
+
 from blocksnet.utils.validation import GdfSchema, LandUseSchema
 
 
 class BlocksSchema(LandUseSchema):
+    """Validate block attributes required for OD modelling."""
+
     population: Series[int] = Field(ge=0)
     site_area: Series[float] = Field(ge=0)
 
 
 def validate_od_matrix(od_mx: pd.DataFrame, graph: nx.Graph):
+    """Verify that an origin-destination matrix aligns with a transport graph."""
+
     if not isinstance(od_mx, pd.DataFrame):
         raise ValueError("Origin destination matrix must be an instance of pd.DataFrame")
     if not all(od_mx.index == od_mx.columns):

--- a/blocksnet/analysis/network/road_congestion/__init__.py
+++ b/blocksnet/analysis/network/road_congestion/__init__.py
@@ -1,1 +1,3 @@
+"""Road congestion modelling utilities."""
+
 from .core import road_congestion

--- a/blocksnet/analysis/network/road_congestion/core.py
+++ b/blocksnet/analysis/network/road_congestion/core.py
@@ -1,15 +1,39 @@
+"""Estimate congestion on a road graph using an OD matrix."""
+
 import pandas as pd
 import networkx as nx
+from tqdm import tqdm
+from loguru import logger
+
 from blocksnet.relations.accessibility import validate_accessibility_graph
 from ..origin_destination import validate_od_matrix
-from tqdm import tqdm
 from blocksnet.config import log_config
-from loguru import logger
 
 CONGESTION_KEY = "congestion"
 
 
 def road_congestion(od_mx: pd.DataFrame, graph: nx.Graph, weight_key: str = "time_min"):
+    """Assign congestion levels to edges based on shortest-path flows.
+
+    Parameters
+    ----------
+    od_mx : pandas.DataFrame
+        Origin-destination matrix with identical index and columns representing node identifiers.
+    graph : networkx.Graph
+        Road graph with edge weights accessible via ``weight_key``.
+    weight_key : str, default ``"time_min"``
+        Edge attribute used to compute shortest paths.
+
+    Returns
+    -------
+    networkx.Graph
+        Copy of ``graph`` with a ``congestion`` attribute accumulated on each edge.
+
+    Raises
+    ------
+    ValueError
+        If the OD matrix or graph do not satisfy validation requirements.
+    """
 
     validate_od_matrix(od_mx, graph)
     validate_accessibility_graph(graph, weight_key)


### PR DESCRIPTION
## Summary
- add NumPy-style documentation for network accessibility, connectivity, origin-destination, and congestion modules
- document network classification context, utilities, and validation schemas

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dc35e989048321bbca044e952cfb0a